### PR TITLE
Adding default hook and context configuration to the project and unit test code injection

### DIFF
--- a/src/Olympus.yyp
+++ b/src/Olympus.yyp
@@ -24,6 +24,7 @@
     {"id":{"name":"demo_olympus_obj_sound_renderer","path":"objects/demo_olympus_obj_sound_renderer/demo_olympus_obj_sound_renderer.yy",},"order":8,},
     {"id":{"name":"demo_olympus_crash_recover","path":"scripts/demo_olympus_crash_recover/demo_olympus_crash_recover.yy",},"order":14,},
     {"id":{"name":"demo_olympus_test_explicit_dependencies","path":"scripts/demo_olympus_test_explicit_dependencies/demo_olympus_test_explicit_dependencies.yy",},"order":11,},
+    {"id":{"name":"demo_olympus_default_hooks","path":"scripts/demo_olympus_default_hooks/demo_olympus_default_hooks.yy",},"order":18,},
     {"id":{"name":"_olympus_async_test_controller","path":"objects/_olympus_async_test_controller/_olympus_async_test_controller.yy",},"order":0,},
     {"id":{"name":"rm_init","path":"rooms/rm_init/rm_init.yy",},"order":0,},
     {"id":{"name":"_olympus_internal","path":"scripts/_olympus_internal/_olympus_internal.yy",},"order":1,},
@@ -75,7 +76,7 @@
   ],
   "IncludedFiles": [],
   "MetaData": {
-    "IDEVersion": "23.1.1.268",
+    "IDEVersion": "23.1.1.382",
   },
   "resourceVersion": "1.4",
   "name": "Olympus",

--- a/src/objects/_olympus_async_test_controller/Create_0.gml
+++ b/src/objects/_olympus_async_test_controller/Create_0.gml
@@ -2,7 +2,7 @@
 _user_feedback_handle = noone;
 _current_test = noone;
 
-_function_to_call_on_test_start = undefined;
-_function_to_call_on_test_finish = undefined;
+_function_to_call_on_test_start = global._olympus_default_hook_before_each_test_start;
+_function_to_call_on_test_finish = global._olympus_default_hook_after_each_test_finish;
 _interval_between_tests = 0;
 _interval_between_tests_counter = 0;

--- a/src/rooms/demo_olympus_rm/RoomCreationCode.gml
+++ b/src/rooms/demo_olympus_rm/RoomCreationCode.gml
@@ -1,4 +1,5 @@
-demo_olympus_quick_start();
+//demo_olympus_quick_start();
+demo_olympus_default_hooks();
 //demo_olympus_test_async();
 //demo_olympus_test_async_with_custom_global_callback_name();
 //demo_olympus_test_async_with_user_feedback();

--- a/src/scripts/demo_olympus_default_hooks/demo_olympus_default_hooks.gml
+++ b/src/scripts/demo_olympus_default_hooks/demo_olympus_default_hooks.gml
@@ -1,0 +1,32 @@
+
+function demo_olympus_default_hooks(){	
+
+	olympus_set_default_test_start_code_injection(function() {
+		show_debug_message("test is starting");
+	});
+
+	olympus_set_default_test_end_code_injection(function() {
+		 // this is still inside the test execution try/catch
+		 throw("Intentional failure");
+		 show_debug_message("This will not show!!");
+	});
+	
+	olympus_set_default_hook_after_each_test_finish(function() {
+		 show_debug_message("This message will show on pass/skip/failed!!");
+		 // A throw here will break Olympus execution.
+		 // throw("Intentional failure");
+	});
+	
+	olympus_run("Accessing test data through hooks", function(){		
+		#region tests
+			xolympus_add_test("Unit test 1", function(){});
+			olympus_add_test("Unit test 2", function(){ throw("Intentional failure")});
+			olympus_add_test("Unit test 3", function(){});
+		#endregion
+		
+	},
+	//Disable the default Olympus logging to not confuse with the logging from the hooks
+	{
+		olympus_suite_options_suppress_debug_logging: true
+	});
+}

--- a/src/scripts/demo_olympus_default_hooks/demo_olympus_default_hooks.yy
+++ b/src/scripts/demo_olympus_default_hooks/demo_olympus_default_hooks.yy
@@ -1,0 +1,12 @@
+{
+  "isDnD": false,
+  "isCompatibility": false,
+  "parent": {
+    "name": "Demo",
+    "path": "folders/Demo.yy",
+  },
+  "resourceVersion": "1.0",
+  "name": "demo_olympus_default_hooks",
+  "tags": [],
+  "resourceType": "GMScript",
+}

--- a/src/scripts/olympus_external_api/olympus_external_api.gml
+++ b/src/scripts/olympus_external_api/olympus_external_api.gml
@@ -58,6 +58,8 @@ function olympus_add_test(name, function_to_execute_synchronous_logic){
 	#macro olympus_test_options_context context
 	#macro olympus_test_options_resolution_context resolution_context
 	#macro olympus_test_options_timeout_millis timeout_millis
+	#macro olympus_test_options_start_code start_code
+	#macro olympus_test_options_end_code end_code
 #endregion
 
 /** 
@@ -135,6 +137,111 @@ function xolympus_add_async_test(name){
 function xolympus_add_async_test_with_user_feedback(name){	
 	var this_test = xolympus_add_async_test(name);
 	return this_test;
+}
+
+/**
+@desc Set a default context to be used for all the tests.
+@param {struct/object} context The context to execute the test in
+*/
+function olympus_set_default_test_context(context){
+	_olympus_forbid_change_during_testing();
+	if (!is_struct(context) && !object_exists(context))
+		throw("Argument should be a struct/object!");
+	else {
+		global._olympus_default_test_context = context
+	}
+}
+
+/**
+@desc Set a default function to be excuted before each test starts. The test summary struct is passed to this function as the first argument.
+@param {function} function_to_execute The function to execute
+@param {struct | instance_id } [context] The optional context to bind the function to. The default uses the calling context.
+*/
+function olympus_set_default_hook_before_each_test_start(function_to_execute){
+	var context = argument_count > 1 ? argument[1] : self
+	if (!is_method(function_to_execute))
+		throw("Argument should be a function!");
+	else {
+		global._olympus_default_hook_before_each_test_start = method(context, function_to_execute);
+	}
+}
+
+/**
+@desc Set a default function to be executed at the start of each test (as part of test's logic, won't count for test duration)
+@param {function} function_to_execute The function to execute
+@param {struct | instance_id } [context] The optional context to bind the function to. The default uses the calling context.
+*/
+function olympus_set_default_test_start_code_injection(function_to_execute){
+	if (!is_method(function_to_execute))
+		throw("Argument should be a function!");
+	else {
+		global._olympus_default_code_injection_after_test_start = method(undefined, function_to_execute);
+	}
+}
+
+/**
+@desc Set a default function to be executed at the end of each test (as part of test's logic, won't count for test duration)
+@param {function} function_to_execute The function to execute
+@param {struct | instance_id } [context] The optional context to bind the function to. The default uses the calling context.
+*/
+function olympus_set_default_test_end_code_injection(function_to_execute){
+	if (!is_method(function_to_execute))
+		throw("Argument should be a function!");
+	else {
+		global._olympus_default_code_injection_before_test_end = method(undefined, function_to_execute);
+	}
+}
+
+/** 
+@desc Set a default function to be excuted after each test finishes. The test summary struct is passed to this function as the first argument.
+@param {function} function_to_execute The function to execute
+@param {struct | instance_id } [context] The optional context to bind the function to. The default uses the calling context.
+*/
+function olympus_set_default_hook_after_each_test_finish(function_to_execute){
+	var context = argument_count > 1 ? argument[1] : self
+	if (!is_method(function_to_execute))
+		throw("Argument should be a function!");
+	else {
+		global._olympus_default_hook_after_each_test_finish = method(context, function_to_execute);
+	}
+}
+
+/** 
+@desc Set a function to be excuted after each test finishes. The test summary struct is passed to this function as the first argument.
+@param {function} function_to_execute The function to execute
+@param {struct | instance_id } [context] The optional context to bind the function to. The default uses the calling context.
+*/
+function olympus_set_hook_after_each_test_finish(function_to_execute){
+	var context = argument_count > 1 ? argument[1] : self
+	_olympus_add_hook_after_each_test_finish(function_to_execute, context);
+}
+
+/**
+@desc Set a default function to be excuted before the suite starts. The suite summary struct is passed to this function as the first argument.
+@param {function} function_to_execute The function to execute
+@param {struct | instance_id } [context] The optional context to bind the function to. The default uses the calling context.
+*/
+function olympus_set_default_hook_before_suite_start(function_to_execute){
+	var context = argument_count > 1 ? argument[1] : self
+	if (!is_method(function_to_execute))
+		throw("Argument should be a function!");
+	else {
+		global._olympus_default_hook_before_suite_start = method(context, function_to_execute);
+	}
+}
+
+/** 
+@desc Set a default function to be excuted after the suite finishes. The suite summary struct is passed to this function as the first argument.
+@param {function} function_to_execute The function to execute
+@param {struct | instance_id } [context] The optional context to bind the function to. The default uses the calling context.
+ */
+function olympus_set_default_hook_after_suite_finish(function_to_execute){
+	var context = argument_count > 1 ? argument[1] : self
+	if (!is_method(function_to_execute))
+		throw("Argument should be a function!");
+	else {
+		global._olympus_default_hook_after_suite_finish = method(context, function_to_execute);
+	}
 }
 
 /**


### PR DESCRIPTION
# Pull Request

## Problem
1. It was not possible to define default hooks for unit tests. This is now possible and is useful when using multiple test suites.
2. It was not possible to inject code into the test itself, so it would run inside the unit test try/catch. This might be useful for some assert libraries that keep a record of multiple asset fails per unit test and throw them at the end of the unit test.

## Solution
I created a couple global variables that can be set to the desired hook functions.
For code injection the respective functions are called before and after the call to the main test function.
